### PR TITLE
Prepare for `0.1.0` release

### DIFF
--- a/malloc_size_of/Cargo.toml
+++ b/malloc_size_of/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "malloc_size_of"
 description = "A an allocator-agnostic crate for measuring the heap size of a value"
-version = "0.1.0-alpha.1"
+version = "0.1.0"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/malloc_size_of"


### PR DESCRIPTION
This PR prepares `malloc_size_of` for release. Given that this represents an initial (non-alpha) crates.io release of `malloc_size_of`, it may be worthwhile reviewing the entire `malloc_size_of` crate (~600 LoC) rather than just the version bump. Assuming that the crate passes code review, it should be ready for publishing.