### PR TITLE
Reduce MSRV to 1.56

### DIFF
--- a/malloc_size_of/Cargo.toml
+++ b/malloc_size_of/Cargo.toml
@@ -6,11 +6,11 @@ authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/malloc_size_of"
 edition = "2021"
+rust-version = "1.56"
 
 [features]
 default = ["std"]
 std = []
-void = ["dep:void"]
 
 [dependencies]
 void = { version = "1.0.2", optional = true }

--- a/malloc_size_of/Cargo.toml
+++ b/malloc_size_of/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "malloc_size_of"
 description = "A an allocator-agnostic crate for measuring the heap size of a value"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/malloc_size_of"


### PR DESCRIPTION
Some of the crates we want to impl `malloc_size_of` for have an MSRV of `1.56`, but the `dep:` syntax wasn't introduced until Rust `1.60`. If a feature is only required to enable a dependency then you can simply not list it, so we do that instead.